### PR TITLE
Handle cmd key on mac

### DIFF
--- a/main.js
+++ b/main.js
@@ -610,8 +610,11 @@ define(function (require, exports, module) {
     }
 
     function handleKey(event) {
+        // Diferentiate Ctrl key from Cmd key on mac platform
+        var ctrlKey = (brackets.platform === "mac") ? event.metaKey : event.ctrlKey;
+        
         // quick check for most common cases
-        if (!event.ctrlKey || event.altKey || event.shiftKey) {
+        if (!ctrlKey || event.altKey || event.shiftKey) {
             // only cases we handle is ctrl with no alt or shift
             return false;
         }


### PR DESCRIPTION
Hi,

This is just a small fix to handle the cmd key in mac instead of the ctrl key. The help panel shows Cmd+ on the commands, but `handleKey` was not checking for that.
