### PR TITLE
Attribute support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,11 @@ Default shortcuts used to generate markup:
   </tr>
   <tr>
     <td><strong>Ctrl-D</strong></td>
-    <td>&lt;del&gt;</td>
+    <td>&lt;div&gt;</td>
+  </tr>
+  <tr>
+    <td><strong>Ctrl-9</strong></td>
+    <td>&lt;br/&gt;</td>
   </tr>
 </table>
 
@@ -103,6 +107,22 @@ Use **Edit &gt; Quick Markup Mode Help** or Ctrl-Shift-M to see a list of all sh
 
 The tags and shortcuts are defined in [data.json](https://github.com/redmunds/brackets-quick-markup/blob/master/data.json),
 so they are fully configurable.
+
+Sample tag shortcuts:
+
+```json
+"p": {                        // shortcut letter, must be unique
+  "tagName": "p",             // tag name (required)
+  "type": "block",            // "block", "heading", or "inline" (required)
+  "attributes": "class='x'"   // attribute string (optional)
+}
+"9": {
+  "tagName": "br",
+  "type": "inline",
+  "isEmpty": true,            // <br> vs <p></p>, default is false
+  "insertTrailingSlash": true // <br> vs <br/>, default is false
+}
+```
 
 Once this extension is installed in Brackets, use **Help > Show Extensions Folder** to navigate
 to the extensions folder. Hint: drag the folder onto Brackets window to quickly switch the current

--- a/data.json
+++ b/data.json
@@ -1,51 +1,51 @@
 {
-    "markupTags": {
+    "shortcuts": {
         "d": {
-            "name": "div",
+            "tagName": "div",
             "type": "block"
         },
         "i": {
-            "name": "em",
+            "tagName": "em",
             "type": "inline"
         },
         "1": {
-            "name": "h1",
+            "tagName": "h1",
             "type": "heading"
         },
         "2": {
-            "name": "h2",
+            "tagName": "h2",
             "type": "heading"
         },
         "3": {
-            "name": "h3",
+            "tagName": "h3",
             "type": "heading"
         },
         "4": {
-            "name": "h4",
+            "tagName": "h4",
             "type": "heading"
         },
         "5": {
-            "name": "h5",
+            "tagName": "h5",
             "type": "heading"
         },
         "6": {
-            "name": "h6",
+            "tagName": "h6",
             "type": "heading"
         },
         "l": {
-            "name": "li",
+            "tagName": "li",
             "type": "block"
         },
         "p": {
-            "name": "p",
+            "tagName": "p",
             "type": "block"
         },
         "b": {
-            "name": "strong",
+            "tagName": "strong",
             "type": "inline"
         },
         "9": {
-            "name": "br",
+            "tagName": "br",
             "type": "inline",
             "isEmpty": true,
             "insertTrailingSlash": true

--- a/data.json
+++ b/data.json
@@ -1,54 +1,54 @@
 {
     "markupTags": {
-        "div": {
-            "type": "block",
-            "shortcut": "d"
+        "d": {
+            "name": "div",
+            "type": "block"
         },
-        "em": {
-            "type": "inline",
-            "shortcut": "i"
+        "i": {
+            "name": "em",
+            "type": "inline"
         },
-        "h1": {
-            "type": "heading",
-            "shortcut": "1"
+        "1": {
+            "name": "h1",
+            "type": "heading"
         },
-        "h2": {
-            "type": "heading",
-            "shortcut": "2"
+        "2": {
+            "name": "h2",
+            "type": "heading"
         },
-        "h3": {
-            "type": "heading",
-            "shortcut": "3"
+        "3": {
+            "name": "h3",
+            "type": "heading"
         },
-        "h4": {
-            "type": "heading",
-            "shortcut": "4"
+        "4": {
+            "name": "h4",
+            "type": "heading"
         },
-        "h5": {
-            "type": "heading",
-            "shortcut": "5"
+        "5": {
+            "name": "h5",
+            "type": "heading"
         },
-        "h6": {
-            "type": "heading",
-            "shortcut": "6"
+        "6": {
+            "name": "h6",
+            "type": "heading"
         },
-        "li": {
-            "type": "block",
-            "shortcut": "l"
+        "l": {
+            "name": "li",
+            "type": "block"
         },
         "p": {
-            "type": "block",
-            "shortcut": "p"
+            "name": "p",
+            "type": "block"
         },
-        "strong": {
-            "type": "inline",
-            "shortcut": "b"
+        "b": {
+            "name": "strong",
+            "type": "inline"
         },
-        "br": {
+        "9": {
+            "name": "br",
             "type": "inline",
             "isEmpty": true,
-            "insertTrailingSlash": true,
-            "shortcut": "9"
+            "insertTrailingSlash": true
         }
     }
 }

--- a/main.js
+++ b/main.js
@@ -156,7 +156,7 @@ define(function (require, exports, module) {
 
     function getTagObjectFromKeyCode(keyCode) {
         var char = String.fromCharCode(keyCode);
-        return data.markupTags[char.toLowerCase()] || data.markupTags[char.toUpperCase()];
+        return data.shortcuts[char.toLowerCase()] || data.shortcuts[char.toUpperCase()];
     }
 
     // There is not a 1:1 correspondence between shortcuts and tag names, but this lookup
@@ -166,10 +166,10 @@ define(function (require, exports, module) {
         var shortcut,
             tagNameLower = tagName.toLowerCase();
 
-        for (shortcut in data.markupTags) {
-            if (data.markupTags.hasOwnProperty(shortcut)) {
-                if (data.markupTags[shortcut].name.toLowerCase() === tagNameLower) {
-                    return data.markupTags[shortcut];
+        for (shortcut in data.shortcuts) {
+            if (data.shortcuts.hasOwnProperty(shortcut)) {
+                if (data.shortcuts[shortcut].tagName.toLowerCase() === tagNameLower) {
+                    return data.shortcuts[shortcut];
                 }
             }
         }
@@ -240,7 +240,7 @@ define(function (require, exports, module) {
             ctx = TokenUtils.getInitialContext(editor._codeMirror, tagRangeStart);
 
         while (TokenUtils.moveSkippingWhitespace(TokenUtils.movePrevToken, ctx)) {
-            if (ctx.token.type === "tag" && ctx.token.string === tag.name) {
+            if (ctx.token.type === "tag" && ctx.token.string === tag.tagName) {
                 // move to prev token to get "<[tag]"
                 TokenUtils.movePrevToken(ctx);
                 tagRangeStart.ch = ctx.token.start;
@@ -258,7 +258,7 @@ define(function (require, exports, module) {
                     closeBracketFound = true;
                 }
             } else if (closeBracketFound) {
-                if (ctx.token.type === "tag" && ctx.token.string === tag.name) {
+                if (ctx.token.type === "tag" && ctx.token.string === tag.tagName) {
                     // move 1 more token to get ">"
                     TokenUtils.moveNextToken(ctx);
                     tagRangeEnd.ch = ctx.token.end;
@@ -273,8 +273,8 @@ define(function (require, exports, module) {
     }
 
     function changeTagName(oldTag, newTag, sel) {
-        var oldTagName = oldTag.name,
-            newTagName = (newTag && newTag.name) || "",
+        var oldTagName = oldTag.tagName,
+            newTagName = (newTag && newTag.tagName) || "",
             selTag = getTagRangeFromIP(oldTag, sel),
             oldTagStr = "",
             newTagStr = "",
@@ -339,10 +339,10 @@ define(function (require, exports, module) {
         }
 
         if (isEmptyTag(tag)) {
-            openTag = insertString = "<" + tag.name + (insertTrailingSlash(tag) ? "/>" : ">");
+            openTag = insertString = "<" + tag.tagName + (insertTrailingSlash(tag) ? "/>" : ">");
         } else {
-            openTag = "<" + tag.name + ">";
-            closeTag = "</" + tag.name + ">";
+            openTag = "<" + tag.tagName + ">";
+            closeTag = "</" + tag.tagName + ">";
             insertString = openTag + selText + closeTag;
         }
 
@@ -610,7 +610,7 @@ define(function (require, exports, module) {
             oldTag,
             edits = [];
 
-        if (newTag.name === oldTagName) {
+        if (newTag.tagName === oldTagName) {
             // same as handling event, but we don't need to do anything
             return noOpEdit(sel);
         }
@@ -632,7 +632,7 @@ define(function (require, exports, module) {
             edits = [];
 
         // if context is same tag, remove it
-        if (oldTag && newTag.name === oldTag.name) {
+        if (oldTag && newTag.tagName === oldTag.tagName) {
             return queueEdits(edits, changeTagName(oldTag, null, sel));
         }
 
@@ -795,8 +795,8 @@ define(function (require, exports, module) {
         origKeymap = $.extend(true, {}, bracketsKeymap);
 
         // Generate list of conflicting shortcuts
-        for (sc in data.markupTags) {
-            if (data.markupTags.hasOwnProperty(sc)) {
+        for (sc in data.shortcuts) {
+            if (data.shortcuts.hasOwnProperty(sc)) {
                 // Check Cmd/Ctrl+key
                 var shortcut = modifier + sc.toUpperCase(),
                     keybinding = origKeymap[shortcut];
@@ -945,8 +945,8 @@ define(function (require, exports, module) {
         }
 
         // Add row for every 3 tags
-        _.forEach(data.markupTags, function (tag, id) {
-            cellData.cells.push({key: id.toUpperCase(), tag: "<" + tag.name + ">"});
+        _.forEach(data.shortcuts, function (tag, id) {
+            cellData.cells.push({key: id.toUpperCase(), tag: "<" + tag.tagName + ">"});
             if (cellData.cells.length === 3) {
                 appendRow();
                 cellData.cells = [];

--- a/main.js
+++ b/main.js
@@ -338,10 +338,16 @@ define(function (require, exports, module) {
             return noOpEdit(sel);
         }
 
+        attrs = tag.attributes || "";
+        // if attribute string starts with non-whitespace then add a space
+        if (attrs.length && /^\S/.test(attrs)) {
+            attrs = " " + attrs;
+        }
+
         if (isEmptyTag(tag)) {
-            openTag = insertString = "<" + tag.tagName + (insertTrailingSlash(tag) ? "/>" : ">");
+            openTag = insertString = "<" + tag.tagName + attrs + (insertTrailingSlash(tag) ? "/>" : ">");
         } else {
-            openTag = "<" + tag.tagName + ">";
+            openTag = "<" + tag.tagName + attrs + ">";
             closeTag = "</" + tag.tagName + ">";
             insertString = openTag + selText + closeTag;
         }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "brackets-quick-markup",
     "title": "Quick Markup",
-    "version": "3.0.2",
+    "version": "3.0.3",
     "description": "Quick Markup allows fast HTML markup generation as you type similar to what how a rich text editor works. Tags and shortcuts are configurable. Multiple cursor support.",
     "homepage": "https://github.com/redmunds/brackets-quick-markup",
     "author": "Randy Edmunds (https://github.com/redmunds)",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "brackets-quick-markup",
     "title": "Quick Markup",
-    "version": "3.0.3",
+    "version": "3.1.0",
     "description": "Quick Markup allows fast HTML markup generation as you type similar to what how a rich text editor works. Tags and shortcuts are configurable. Multiple cursor support.",
     "homepage": "https://github.com/redmunds/brackets-quick-markup",
     "author": "Randy Edmunds (https://github.com/redmunds)",

--- a/unittests.js
+++ b/unittests.js
@@ -639,7 +639,7 @@ define(function (require, exports, module) {
             });
 
             it("should insert empty tag at IP without trailing slash", function () {
-                var brTag = QuickMarkup._data.markupTags.br,
+                var brTag = QuickMarkup._data.markupTags["9"],
                     trailingSlash = brTag.insertTrailingSlash;
                 brTag.insertTrailingSlash = false;
 

--- a/unittests.js
+++ b/unittests.js
@@ -444,6 +444,20 @@ define(function (require, exports, module) {
                 expect(testEditor.getCursorPos()).toEqual({ line: 6, ch: 13 });
             });
 
+            it("should insert block level tag at IP with attributes", function () {
+                // 'attributes' property is currently not used in data.json, so temporarily set it
+                var divTag = QuickMarkup._data.shortcuts.d,
+                    attrs = divTag.attributes;
+                divTag.attributes = "class='test'";
+
+                testEditor.setCursorPos({ line: 6, ch: 8 });
+                QuickMarkup._handleKey(makeCtrlKeyEvent(KeyEvent.DOM_VK_D), testDocument, testEditor);
+                expect(testDocument.getLine(6)).toEqual("        <div class='test'></div>");
+                expect(testEditor.getCursorPos()).toEqual({ line: 6, ch: 26 });
+
+                divTag.attributes = attrs;
+            });
+
             it("should insert heading tag at IP", function () {
                 testEditor.setCursorPos({ line: 6, ch: 8 });
                 QuickMarkup._handleKey(makeCtrlKeyEvent(KeyEvent.DOM_VK_3), testDocument, testEditor);
@@ -639,7 +653,8 @@ define(function (require, exports, module) {
             });
 
             it("should insert empty tag at IP without trailing slash", function () {
-                var brTag = QuickMarkup._data.markupTags["9"],
+                // 'insertTrailingSlash':false is currently not used in data.json, so temporarily set it
+                var brTag = QuickMarkup._data.shortcuts["9"],
                     trailingSlash = brTag.insertTrailingSlash;
                 brTag.insertTrailingSlash = false;
 


### PR DESCRIPTION
This implements attributes support as inspired by pull request #34

Needed to refactor data to use shortcut as key (which must be unique) instead of using tag name (which could be duplicated with different attributes), and refactor code that references the data.
