### PR TITLE
Remove JSON syntax coloring

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ so they are fully configurable.
 
 Sample tag shortcuts:
 
-```json
+```
 "p": {                        // shortcut letter, must be unique
   "tagName": "p",             // tag name (required)
   "type": "block",            // "block", "heading", or "inline" (required)


### PR DESCRIPTION
The JSON syntax coloring marks comments as invalid. Technically, comments are not allowed in JSON, but they're just used for documentation.