### PR TITLE
Edited keyboard shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is an Extension for [Brackets](https://github.com/adobe/brackets).
 
 ## Features
 
-This extension is accessed in Brackets using menu **Edit &gt; Quick Markup Mode** or Ctrl-M.
+This extension is accessed in Brackets using menu **Edit &gt; Quick Markup Mode** or Ctrl-Shift-M.
 
 A minimal bottom panel is displayed to indicate you are in quick markup mode. A &quot;mode&quot;
 is required because this extension uses a lot of keyboard shortcuts which conflict with
@@ -101,7 +101,7 @@ Default shortcuts used to generate markup:
 
 **Note:** Ctrl refers to Ctrl key on Windows or Cmd key on Mac.
 
-Use **Edit &gt; Quick Markup Mode Help** or Ctrl-Shift-M to see a list of all shortcuts used by this extension.
+Use **Edit &gt; Quick Markup Mode Help** or Ctrl-Alt-M to see a list of all shortcuts used by this extension.
 
 ##Configuration
 

--- a/main.js
+++ b/main.js
@@ -983,7 +983,7 @@ define(function (require, exports, module) {
             cmdHelp.setChecked(helpQuickMarkup);
         }
 
-        // Add command to end of edit menu, if it exists
+        // Add command to end of edit menu, if it exists 
         var edit_menu = Menus.getMenu(Menus.AppMenuBar.EDIT_MENU);
         if (edit_menu) {
             edit_menu.addMenuDivider();

--- a/main.js
+++ b/main.js
@@ -987,8 +987,8 @@ define(function (require, exports, module) {
         var edit_menu = Menus.getMenu(Menus.AppMenuBar.EDIT_MENU);
         if (edit_menu) {
             edit_menu.addMenuDivider();
-            edit_menu.addMenuItem(TOGGLE_QUICK_MARKUP,      "Ctrl-M");
-            edit_menu.addMenuItem(TOGGLE_QUICK_MARKUP_HELP, "Ctrl-Shift-M");
+            edit_menu.addMenuItem(TOGGLE_QUICK_MARKUP,      "Ctrl-Shift-M");
+            edit_menu.addMenuItem(TOGGLE_QUICK_MARKUP_HELP, "Ctrl-Alt-M");
         }
     
         MainViewManager.on("currentFileChange", handleCurrentFileChange);

--- a/main.js
+++ b/main.js
@@ -983,7 +983,7 @@ define(function (require, exports, module) {
             cmdHelp.setChecked(helpQuickMarkup);
         }
 
-        // Add command to end of edit menu, if it exists 
+        // Add command to end of edit menu, if it exists
         var edit_menu = Menus.getMenu(Menus.AppMenuBar.EDIT_MENU);
         if (edit_menu) {
             edit_menu.addMenuDivider();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "brackets-quick-markup",
     "title": "Quick Markup",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "description": "Quick Markup allows fast HTML markup generation as you type similar to what how a rich text editor works. Tags and shortcuts are configurable. Multiple cursor support.",
     "homepage": "https://github.com/redmunds/brackets-quick-markup",
     "author": "Randy Edmunds (https://github.com/redmunds)",

--- a/templates/bottom-panel.html
+++ b/templates/bottom-panel.html
@@ -1,6 +1,6 @@
 <div id="quick-markup" class="bottom-panel">
   <div class="toolbar simple-toolbar-layout">
-    <span class="title">Quick Markup Mode</span> &mdash; {{keyString}}-M to toggle mode. {{keyString}}-Shift-M to toggle help. 
+    <span class="title">Quick Markup Mode</span> &mdash; {{keyString}}-Shift-M to toggle mode. {{keyString}}-Alt-M to toggle help. 
   </div>
   <div class="qm-content">
     <table>


### PR DESCRIPTION
Cmd-M (previous shortcut to toggle QM) conflicted with a default OSX shortcut.

New shortcuts are as follows:

Cmd-Shift-M = Toggle Quick Markup
Cmd-Option-M = Toggle Quick Markup Help

Note:
Cmd-Shift-M = Ctrl-Shift-M
Cmd-Option-M = Ctrl-Alt-M