### PR TITLE
better customization of the bottom panel

### DIFF
--- a/main.js
+++ b/main.js
@@ -952,7 +952,8 @@ define(function (require, exports, module) {
 
         // Add row for every 3 tags
         _.forEach(data.shortcuts, function (tag, id) {
-            cellData.cells.push({key: id.toUpperCase(), tag: "<" + tag.tagName + ">"});
+            var tagDisplay = tag.tagDisplay || tag.tagName;
+            cellData.cells.push({key: id.toUpperCase(), tag: "<" + tagDisplay + ">"});
             if (cellData.cells.length === 3) {
                 appendRow();
                 cellData.cells = [];


### PR DESCRIPTION
This is for #44. A solution given by Randy Edmunds.

This change adds the possibility of better customizing the bottom panel by giving a more explicit description of each shortcut using the new "tagDisplay" field in the .json file. If the tagDisplay is empty, it uses the tagName as before.

in the .json file a shortcut might look as follows:
```json
 "2": {
            "tagName": "span",
            "tagDisplay": "span/i-menos-esp-letras-10",
            "type": "inline",
            "attributes": "class='i-menos-esp-letras-10'"
        },
```